### PR TITLE
fix redis_globals, make shared at snaphot build

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -1,7 +1,7 @@
 // vim: ft=javascript:
 
-ARG_ENABLE("redis", "whether to enable redis support", "yes");
-ARG_ENABLE("redis-session", "whether to enable sessions", "yes");
+ARG_ENABLE("redis", "whether to enable redis support", "no");
+ARG_ENABLE("redis-session", "whether to enable sessions", "no");
 ARG_ENABLE("redis-igbinary", "whether to enable igbinary serializer support", "no");
 
 if (PHP_REDIS != "no") {

--- a/redis.c
+++ b/redis.c
@@ -98,7 +98,9 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_kscan, 0, 0, 2)
     ZEND_ARG_INFO(0, i_count)
 ZEND_END_ARG_INFO();
 
+#ifdef ZTS
 ZEND_DECLARE_MODULE_GLOBALS(redis)
+#endif
 
 static zend_function_entry redis_functions[] = {
      PHP_ME(Redis, __construct, NULL, ZEND_ACC_CTOR | ZEND_ACC_PUBLIC)


### PR DESCRIPTION
@edtechd Fixed 2 things.Now I am getting only this error:

```
Creating library C:\php-sdk\php70dev\Release_TS\php_redis.lib and object C:\php-sdk\php70dev\Release_TS\php_redis.exp
library.obj : error LNK2001: unresolved external symbol _basic_globals_id
C:\php-sdk\php70dev\Release_TS\php_redis.dll : fatal error LNK1120: 1 unresolved externals
NMAKE : fatal error U1077: '"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\BIN\link.exe"' return code '0x460'
```

Must be something simple. I'll ask @rlerdorf
