### PR TITLE
fix missing _basic_globals / _basic_globals_id

### DIFF
--- a/library.c
+++ b/library.c
@@ -30,9 +30,23 @@
 #define SCORE_DECODE_INT  1
 #define SCORE_DECODE_DOUBLE 2
 
+#ifdef ZTS
+    #ifndef basic_globals_id
+    PHPAPI int basic_globals_id;
+    #endif
+#else
+    #ifndef basic_globals
+    PHPAPI php_basic_globals basic_globals;
+    #endif
+#endif
+
 #ifdef PHP_WIN32
     # if PHP_MAJOR_VERSION == 5 && PHP_MINOR_VERSION <= 4
         /* This proto is available from 5.5 on only */
+        PHPAPI int usleep(unsigned int useconds);
+    # endif
+    # if PHP_MAJOR_VERSION == 7
+        /* This proto is available in PHP7 */
         PHPAPI int usleep(unsigned int useconds);
     # endif
 #endif


### PR DESCRIPTION
This one makes it compile. I tried including "ext/standard/basic_functions.h", but that caused other errors, so I copied only the essential part. Including basic_functions.h however is preferable if you or me can make that to work.
