### PR TITLE
Other fix _basic_globals / _basic_globals_id

### DIFF
--- a/cluster_library.c
+++ b/cluster_library.c
@@ -306,7 +306,7 @@ static int cluster_send_multi(redisCluster *c, short slot TSRMLS_DC) {
  * here because we know we'll only have sent MULTI to the master nodes.  We can't
  * failover inside a transaction, as we don't know if the transaction will only
  * be readonly commands, or contain write commands as well */
-PHPAPI int cluster_send_exec(redisCluster *c, short slot TSRMLS_DC) {
+PHP_REDIS_API int cluster_send_exec(redisCluster *c, short slot TSRMLS_DC) {
     int retval;
 
     /* Send exec */
@@ -321,7 +321,7 @@ PHPAPI int cluster_send_exec(redisCluster *c, short slot TSRMLS_DC) {
     return retval;
 }
 
-PHPAPI int cluster_send_discard(redisCluster *c, short slot TSRMLS_DC) {
+PHP_REDIS_API int cluster_send_discard(redisCluster *c, short slot TSRMLS_DC) {
     if (cluster_send_direct(SLOT_SOCK(c,slot), RESP_DISCARD_CMD,
         sizeof(RESP_DISCARD_CMD)-1, TYPE_LINE TSRMLS_CC))
     {
@@ -654,7 +654,7 @@ cluster_node_create(redisCluster *c, char *host, size_t host_len,
 }
 
 /* Attach a slave to a master */
-PHPAPI int
+PHP_REDIS_API int
 cluster_node_add_slave(redisClusterNode *master, redisClusterNode *slave)
 {
     ulong index;
@@ -744,7 +744,7 @@ static int cluster_map_slots(redisCluster *c, clusterReply *r) {
 }
 
 /* Free a redisClusterNode structure */
-PHPAPI void cluster_free_node(redisClusterNode *node) {
+PHP_REDIS_API void cluster_free_node(redisClusterNode *node) {
     if(node->slaves) {
         zend_hash_destroy(node->slaves);
         efree(node->slaves);
@@ -782,7 +782,7 @@ static RedisSock *cluster_get_asking_sock(redisCluster *c TSRMLS_DC) {
 }
 
 /* Initialize seeds */
-PHPAPI int
+PHP_REDIS_API int
 cluster_init_seeds(redisCluster *cluster, HashTable *ht_seeds) {
     RedisSock *redis_sock;
     char *str, *psep, key[1024];
@@ -821,7 +821,7 @@ cluster_init_seeds(redisCluster *cluster, HashTable *ht_seeds) {
 }
 
 /* Initial mapping of our cluster keyspace */
-PHPAPI int
+PHP_REDIS_API int
 cluster_map_keyspace(redisCluster *c TSRMLS_DC) {
     RedisSock *seed;
     clusterReply *slots=NULL;
@@ -962,7 +962,7 @@ static int cluster_check_response(redisCluster *c, REDIS_REPLY_TYPE *reply_type
 }
 
 /* Disconnect from each node we're connected to */
-PHPAPI void cluster_disconnect(redisCluster *c TSRMLS_DC) {
+PHP_REDIS_API void cluster_disconnect(redisCluster *c TSRMLS_DC) {
     redisClusterNode *node;
 
     ZEND_HASH_FOREACH_PTR(c->nodes, node) {
@@ -1189,7 +1189,7 @@ static void cluster_update_slot(redisCluster *c TSRMLS_DC) {
 /* Abort any transaction in process, by sending DISCARD to any nodes that
  * have active transactions in progress.  If we can't send DISCARD, we need
  * to disconnect as it would leave us in an undefined state. */
-PHPAPI int cluster_abort_exec(redisCluster *c TSRMLS_DC) {
+PHP_REDIS_API int cluster_abort_exec(redisCluster *c TSRMLS_DC) {
     clusterFoldItem *fi = c->multi_head;
 
     /* Loop through our fold items */
@@ -1215,7 +1215,7 @@ PHPAPI int cluster_abort_exec(redisCluster *c TSRMLS_DC) {
 /* Iterate through our slots, looking for the host/port in question.  This
  * should perform well enough as in almost all situations, a few or a few
  * dozen servers will map all the slots */
-PHPAPI short cluster_find_slot(redisCluster *c, const char *host,
+PHP_REDIS_API short cluster_find_slot(redisCluster *c, const char *host,
                                unsigned short port)
 {
     int i;
@@ -1234,7 +1234,7 @@ PHPAPI short cluster_find_slot(redisCluster *c, const char *host,
 }
 
 /* Send a command to a specific slot */
-PHPAPI int cluster_send_slot(redisCluster *c, short slot, char *cmd,
+PHP_REDIS_API int cluster_send_slot(redisCluster *c, short slot, char *cmd,
                              int cmd_len, REDIS_REPLY_TYPE rtype TSRMLS_DC)
 {
     /* Point our cluster to this slot and it's socket */
@@ -1267,7 +1267,7 @@ PHPAPI int cluster_send_slot(redisCluster *c, short slot, char *cmd,
 
 /* Send a command to given slot in our cluster.  If we get a MOVED or ASK error
  * we attempt to send the command to the node as directed. */
-PHPAPI short cluster_send_command(redisCluster *c, short slot, const char *cmd,
+PHP_REDIS_API short cluster_send_command(redisCluster *c, short slot, const char *cmd,
                                   int cmd_len TSRMLS_DC)
 {
     int resp, timedout=0;
@@ -1355,7 +1355,7 @@ PHPAPI short cluster_send_command(redisCluster *c, short slot, const char *cmd,
  * consumed. */
 
 /* RAW bulk response handler */
-PHPAPI void cluster_bulk_raw_resp(INTERNAL_FUNCTION_PARAMETERS,
+PHP_REDIS_API void cluster_bulk_raw_resp(INTERNAL_FUNCTION_PARAMETERS,
                                   redisCluster *c, void *ctx)
 {
     char *resp;
@@ -1376,7 +1376,7 @@ PHPAPI void cluster_bulk_raw_resp(INTERNAL_FUNCTION_PARAMETERS,
 }
 
 /* BULK response handler */
-PHPAPI void cluster_bulk_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
+PHP_REDIS_API void cluster_bulk_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
                               void *ctx)
 {
     char *resp;
@@ -1408,7 +1408,7 @@ PHPAPI void cluster_bulk_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
 }
 
 /* Bulk response where we expect a double */
-PHPAPI void cluster_dbl_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
+PHP_REDIS_API void cluster_dbl_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
                              void *ctx)
 {
     char *resp;
@@ -1430,7 +1430,7 @@ PHPAPI void cluster_dbl_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
 
 /* A boolean response.  If we get here, we've consumed the '+' reply
  * type and will now just verify we can read the OK */
-PHPAPI void cluster_bool_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
+PHP_REDIS_API void cluster_bool_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
                               void *ctx)
 {
     // Check that we have +OK
@@ -1444,7 +1444,7 @@ PHPAPI void cluster_bool_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
 }
 
 /* Boolean response, specialized for PING */
-PHPAPI void cluster_ping_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
+PHP_REDIS_API void cluster_ping_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
                               void *ctx)
 {
     if(c->reply_type != TYPE_LINE || c->reply_len != 4 ||
@@ -1457,7 +1457,7 @@ PHPAPI void cluster_ping_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
 }
 
 /* 1 or 0 response, for things like SETNX */
-PHPAPI void cluster_1_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
+PHP_REDIS_API void cluster_1_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
                            void *ctx)
 {
     // Validate our reply type, and check for a zero
@@ -1469,7 +1469,7 @@ PHPAPI void cluster_1_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
 }
 
 /* Generic integer response */
-PHPAPI void cluster_long_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
+PHP_REDIS_API void cluster_long_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
                               void *ctx)
 {
     if(c->reply_type != TYPE_INT) {
@@ -1479,7 +1479,7 @@ PHPAPI void cluster_long_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
 }
 
 /* TYPE response handler */
-PHPAPI void cluster_type_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
+PHP_REDIS_API void cluster_type_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
                               void *ctx)
 {
     // Make sure we got the right kind of response
@@ -1504,7 +1504,7 @@ PHPAPI void cluster_type_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
 }
 
 /* SUBSCRIBE/PSCUBSCRIBE handler */
-PHPAPI void cluster_sub_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
+PHP_REDIS_API void cluster_sub_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
                              void *ctx)
 {
     subscribeContext *sctx = (subscribeContext*)ctx;
@@ -1633,7 +1633,7 @@ PHPAPI void cluster_sub_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
 }
 
 /* UNSUBSCRIBE/PUNSUBSCRIBE */
-PHPAPI void cluster_unsub_resp(INTERNAL_FUNCTION_PARAMETERS,
+PHP_REDIS_API void cluster_unsub_resp(INTERNAL_FUNCTION_PARAMETERS,
                                redisCluster *c, void *ctx)
 {
     subscribeContext *sctx = (subscribeContext*)ctx;
@@ -1715,7 +1715,7 @@ static void cluster_mbulk_variant_resp(clusterReply *r, zval *z_ret)
 
 /* Variant response handling, for things like EVAL and various other responses
  * where we just map the replies from Redis type values to PHP ones directly. */
-PHPAPI void cluster_variant_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
+PHP_REDIS_API void cluster_variant_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
                                  void *ctx)
 {
     clusterReply *r;
@@ -1784,7 +1784,7 @@ PHPAPI void cluster_variant_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
 }
 
 /* Generic MULTI BULK response processor */
-PHPAPI void cluster_gen_mbulk_resp(INTERNAL_FUNCTION_PARAMETERS,
+PHP_REDIS_API void cluster_gen_mbulk_resp(INTERNAL_FUNCTION_PARAMETERS,
                                    redisCluster *c, mbulk_cb cb, void *ctx)
 {
     zval z_result;
@@ -1820,7 +1820,7 @@ PHPAPI void cluster_gen_mbulk_resp(INTERNAL_FUNCTION_PARAMETERS,
 }
 
 /* HSCAN, SSCAN, ZSCAN */
-PHPAPI int cluster_scan_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
+PHP_REDIS_API int cluster_scan_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
                               REDIS_SCAN_TYPE type, long *it)
 {
     char *pit;
@@ -1877,7 +1877,7 @@ PHPAPI int cluster_scan_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
 }
 
 /* INFO response */
-PHPAPI void cluster_info_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
+PHP_REDIS_API void cluster_info_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
                               void *ctx)
 {
     zval *z_result;
@@ -1903,7 +1903,7 @@ PHPAPI void cluster_info_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
 }
 
 /* CLIENT LIST response */
-PHPAPI void cluster_client_list_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
+PHP_REDIS_API void cluster_client_list_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
                                      void *ctx)
 {
     zval *z_result;
@@ -1928,7 +1928,7 @@ PHPAPI void cluster_client_list_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster 
 }
 
 /* MULTI BULK response loop where we might pull the next one */
-PHPAPI zval *cluster_zval_mbulk_resp(INTERNAL_FUNCTION_PARAMETERS,
+PHP_REDIS_API zval *cluster_zval_mbulk_resp(INTERNAL_FUNCTION_PARAMETERS,
                                      redisCluster *c, int pull, mbulk_cb cb)
 {
     zval z_result;
@@ -1963,7 +1963,7 @@ PHPAPI zval *cluster_zval_mbulk_resp(INTERNAL_FUNCTION_PARAMETERS,
 }
 
 /* MULTI MULTI BULK reply (for EXEC) */
-PHPAPI void cluster_multi_mbulk_resp(INTERNAL_FUNCTION_PARAMETERS,
+PHP_REDIS_API void cluster_multi_mbulk_resp(INTERNAL_FUNCTION_PARAMETERS,
                                      redisCluster *c, void *ctx)
 {
 	clusterFoldItem *fi;
@@ -2000,7 +2000,7 @@ PHPAPI void cluster_multi_mbulk_resp(INTERNAL_FUNCTION_PARAMETERS,
 }
 
 /* Generic handler for MGET */
-PHPAPI void cluster_mbulk_mget_resp(INTERNAL_FUNCTION_PARAMETERS,
+PHP_REDIS_API void cluster_mbulk_mget_resp(INTERNAL_FUNCTION_PARAMETERS,
                                     redisCluster *c, void *ctx)
 {
 	short fail;
@@ -2035,7 +2035,7 @@ PHPAPI void cluster_mbulk_mget_resp(INTERNAL_FUNCTION_PARAMETERS,
 }
 
 /* Handler for MSETNX */
-PHPAPI void cluster_msetnx_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
+PHP_REDIS_API void cluster_msetnx_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
                                 void *ctx)
 {
     clusterMultiCtx *mctx = (clusterMultiCtx*)ctx;
@@ -2071,7 +2071,7 @@ PHPAPI void cluster_msetnx_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
 }
 
 /* Handler for DEL */
-PHPAPI void cluster_del_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
+PHP_REDIS_API void cluster_del_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
                              void *ctx)
 {
     clusterMultiCtx *mctx = (clusterMultiCtx*)ctx;
@@ -2100,7 +2100,7 @@ PHPAPI void cluster_del_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
 }
 
 /* Handler for MSET */
-PHPAPI void cluster_mset_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
+PHP_REDIS_API void cluster_mset_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
                               void *ctx)
 {
     clusterMultiCtx *mctx = (clusterMultiCtx*)ctx;
@@ -2130,7 +2130,7 @@ PHPAPI void cluster_mset_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
 }
 
 /* Raw MULTI BULK reply */
-PHPAPI void
+PHP_REDIS_API void
 cluster_mbulk_raw_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c, void *ctx)
 {
     cluster_gen_mbulk_resp(INTERNAL_FUNCTION_PARAM_PASSTHRU, c,
@@ -2138,7 +2138,7 @@ cluster_mbulk_raw_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c, void *ctx)
 }
 
 /* Unserialize all the things */
-PHPAPI void
+PHP_REDIS_API void
 cluster_mbulk_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c, void *ctx)
 {
     cluster_gen_mbulk_resp(INTERNAL_FUNCTION_PARAM_PASSTHRU, c,
@@ -2147,7 +2147,7 @@ cluster_mbulk_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c, void *ctx)
 
 /* For handling responses where we get key, value, key, value that
  * we will turn into key => value, key => value. */
-PHPAPI void
+PHP_REDIS_API void
 cluster_mbulk_zipstr_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
                           void *ctx)
 {
@@ -2156,7 +2156,7 @@ cluster_mbulk_zipstr_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
 }
 
 /* Handling key,value to key=>value where the values are doubles */
-PHPAPI void
+PHP_REDIS_API void
 cluster_mbulk_zipdbl_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
                           void *ctx)
 {
@@ -2165,7 +2165,7 @@ cluster_mbulk_zipdbl_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
 }
 
 /* Associate multi bulk response (for HMGET really) */
-PHPAPI void
+PHP_REDIS_API void
 cluster_mbulk_assoc_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
                          void *ctx)
 {

--- a/config.w32
+++ b/config.w32
@@ -1,13 +1,12 @@
 // vim: ft=javascript:
 
 ARG_ENABLE("redis", "whether to enable redis support", "no");
-ARG_ENABLE("redis-session", "whether to enable sessions", "no");
-ARG_ENABLE("redis-igbinary", "whether to enable igbinary serializer support", "no");
+ARG_ENABLE("redis-session", "whether to enable sessions", "yes");
+ARG_ENABLE("redis-igbinary", "whether to enable igbinary serializer support", "yes");
 
 if (PHP_REDIS != "no") {
-	EXTENSION("redis", "redis.c library.c redis_commands.c redis_array.c redis_array_impl.c redis_cluster.c cluster_library.c");
+	var sources = "redis.c library.c redis_commands.c redis_array.c redis_array_impl.c redis_cluster.c cluster_library.c";
 	AC_DEFINE("HAVE_REDIS", 1);
-	ADD_FLAG("CFLAGS_REDIS", ' /D PHP_EXPORTS=1 ');
 
 	if (PHP_REDIS_SESSION != "no") {
 		ADD_SOURCES(configure_module_dirname, "redis_session.c", "redis");
@@ -26,6 +25,6 @@ if (PHP_REDIS != "no") {
 		}
 	}
 	
-
+	EXTENSION("redis", sources);
 }
 

--- a/library.c
+++ b/library.c
@@ -30,18 +30,6 @@
 #define SCORE_DECODE_INT  1
 #define SCORE_DECODE_DOUBLE 2
 
-/*
-#ifdef ZTS
-    #ifndef basic_globals_id
-    PHP_REDIS_API int basic_globals_id;
-    #endif
-#else
-    #ifndef basic_globals
-    PHP_REDIS_API php_basic_globals basic_globals;
-    #endif
-#endif
-*/
-
 #ifdef PHP_WIN32
     # if PHP_MAJOR_VERSION == 5 && PHP_MINOR_VERSION <= 4
         /* This proto is available from 5.5 on only */

--- a/redis.c
+++ b/redis.c
@@ -358,7 +358,7 @@ zend_module_entry redis_module_entry = {
 ZEND_GET_MODULE(redis)
 #endif
 
-PHPAPI zend_class_entry *redis_get_exception_base(int root TSRMLS_DC)
+PHP_REDIS_API zend_class_entry *redis_get_exception_base(int root TSRMLS_DC)
 {
 #if HAVE_SPL
     if (!root) {
@@ -423,7 +423,7 @@ static void redis_destructor_redis_sock(zend_resource * rsrc TSRMLS_DC)
 /**
  * redis_sock_get
  */
-PHPAPI int redis_sock_get(zval *id, RedisSock **redis_sock TSRMLS_DC, 
+PHP_REDIS_API int redis_sock_get(zval *id, RedisSock **redis_sock TSRMLS_DC, 
         int no_throw)
 {
 
@@ -464,7 +464,7 @@ PHPAPI int redis_sock_get(zval *id, RedisSock **redis_sock TSRMLS_DC,
  * redis_sock_get_direct
  * Returns our attached RedisSock pointer if we're connected
  */
-PHPAPI RedisSock *redis_sock_get_connected(INTERNAL_FUNCTION_PARAMETERS) {
+PHP_REDIS_API RedisSock *redis_sock_get_connected(INTERNAL_FUNCTION_PARAMETERS) {
     zval *object;
     RedisSock *redis_sock;
 
@@ -698,7 +698,7 @@ PHP_METHOD(Redis, pconnect)
 }
 /* }}} */
 
-PHPAPI int redis_connect(INTERNAL_FUNCTION_PARAMETERS, int persistent) {
+PHP_REDIS_API int redis_connect(INTERNAL_FUNCTION_PARAMETERS, int persistent) {
     zval *object;
     zval *socket;
     int host_len;
@@ -1031,12 +1031,12 @@ PHP_METHOD(Redis, delete)
 }
 /* }}} */
 
-PHPAPI void redis_set_watch(RedisSock *redis_sock)
+PHP_REDIS_API void redis_set_watch(RedisSock *redis_sock)
 {
     redis_sock->watching = 1;
 }
 
-PHPAPI void redis_watch_response(INTERNAL_FUNCTION_PARAMETERS, 
+PHP_REDIS_API void redis_watch_response(INTERNAL_FUNCTION_PARAMETERS, 
         RedisSock *redis_sock, zval *z_tab, void *ctx)
 {
     redis_boolean_response_impl(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock, 
@@ -1051,12 +1051,12 @@ PHP_METHOD(Redis, watch)
 }
 /* }}} */
 
-PHPAPI void redis_clear_watch(RedisSock *redis_sock)
+PHP_REDIS_API void redis_clear_watch(RedisSock *redis_sock)
 {
     redis_sock->watching = 0;
 }
 
-PHPAPI void redis_unwatch_response(INTERNAL_FUNCTION_PARAMETERS, 
+PHP_REDIS_API void redis_unwatch_response(INTERNAL_FUNCTION_PARAMETERS, 
         RedisSock *redis_sock, zval *z_tab, 
         void *ctx)
 {
@@ -1384,7 +1384,7 @@ PHP_METHOD(Redis, sort) {
     }
 }
 
-PHPAPI void generic_sort_cmd(INTERNAL_FUNCTION_PARAMETERS, char *sort, 
+PHP_REDIS_API void generic_sort_cmd(INTERNAL_FUNCTION_PARAMETERS, char *sort, 
         int use_alpha) 
 {
 
@@ -1780,7 +1780,7 @@ PHP_METHOD(Redis, move) {
 }
 /* }}} */
 
-PHPAPI void
+PHP_REDIS_API void
 generic_mset(INTERNAL_FUNCTION_PARAMETERS, char *kw, ResultCallback fun) {
     zval *object;
     RedisSock *redis_sock;
@@ -2254,7 +2254,7 @@ PHP_METHOD(Redis, discard)
     redis_send_discard(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock);
 }
 
-    PHPAPI int 
+    PHP_REDIS_API int 
 redis_sock_read_multibulk_pipeline_reply(INTERNAL_FUNCTION_PARAMETERS, 
         RedisSock *redis_sock)
 {
@@ -2274,7 +2274,7 @@ redis_sock_read_multibulk_pipeline_reply(INTERNAL_FUNCTION_PARAMETERS,
 }
 
 /* redis_sock_read_multibulk_multi_reply */
-PHPAPI int redis_sock_read_multibulk_multi_reply(INTERNAL_FUNCTION_PARAMETERS,
+PHP_REDIS_API int redis_sock_read_multibulk_multi_reply(INTERNAL_FUNCTION_PARAMETERS,
         RedisSock *redis_sock)
 {
 
@@ -2423,7 +2423,7 @@ PHP_METHOD(Redis, exec)
     }
 }
 
-PHPAPI int redis_response_enqueued(RedisSock *redis_sock TSRMLS_DC) {
+PHP_REDIS_API int redis_response_enqueued(RedisSock *redis_sock TSRMLS_DC) {
     char *resp;
     int resp_len, ret = 0;
 
@@ -2438,14 +2438,14 @@ PHPAPI int redis_response_enqueued(RedisSock *redis_sock TSRMLS_DC) {
     return ret;
 }
 
-PHPAPI void fold_this_item(INTERNAL_FUNCTION_PARAMETERS, fold_item *item, 
+PHP_REDIS_API void fold_this_item(INTERNAL_FUNCTION_PARAMETERS, fold_item *item, 
         RedisSock *redis_sock, zval *z_tab) 
 {
     item->fun(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock, z_tab, item->ctx 
             TSRMLS_CC);
 }
 
-    PHPAPI int 
+    PHP_REDIS_API int 
 redis_sock_read_multibulk_multi_reply_loop(INTERNAL_FUNCTION_PARAMETERS,
         RedisSock *redis_sock, zval *z_tab, 
         int numElems)
@@ -2518,7 +2518,7 @@ PHP_METHOD(Redis, subscribe) {
  * );
  **/
 
-PHPAPI void generic_unsubscribe_cmd(INTERNAL_FUNCTION_PARAMETERS, 
+PHP_REDIS_API void generic_unsubscribe_cmd(INTERNAL_FUNCTION_PARAMETERS, 
         char *unsub_cmd)
 {
     zval *object, *array, *data;
@@ -2860,7 +2860,7 @@ PHP_METHOD(Redis, wait) {
 }
 
 /* Construct a PUBSUB command */
-    PHPAPI int
+    PHP_REDIS_API int
 redis_build_pubsub_cmd(RedisSock *redis_sock, char **ret, PUBSUB_TYPE type,
         zval *arg TSRMLS_DC)
 {
@@ -3020,7 +3020,7 @@ PHP_METHOD(Redis, pubsub) {
 
 // Construct an EVAL or EVALSHA command, with option argument array and number 
 // of arguments that are keys parameter
-PHPAPI int
+PHP_REDIS_API int
 redis_build_eval_cmd(RedisSock *redis_sock, char **ret, char *keyword, 
         char *value, int val_len, zval *args, int keys_count 
         TSRMLS_DC) 
@@ -3175,7 +3175,7 @@ PHP_METHOD(Redis, eval)
     REDIS_PROCESS_RESPONSE(redis_read_variant_reply);
 }
 
-PHPAPI int
+PHP_REDIS_API int
 redis_build_script_exists_cmd(char **ret, zval *argv, int argc) {
     // Our command length and iterator
     int cmd_len = 0, i;
@@ -3628,7 +3628,7 @@ PHP_METHOD(Redis, rawcommand) {
 /* }}} */
 
 /* Helper to format any combination of SCAN arguments */
-    PHPAPI int
+    PHP_REDIS_API int
 redis_build_scan_cmd(char **cmd, REDIS_SCAN_TYPE type, char *key, int key_len,
         int iter, char *pattern, int pattern_len, int count)
 {
@@ -3686,7 +3686,7 @@ redis_build_scan_cmd(char **cmd, REDIS_SCAN_TYPE type, char *key, int key_len,
 }
 
 /* {{{ proto redis::scan(&$iterator, [pattern, [count]]) */
-PHPAPI void
+PHP_REDIS_API void
 generic_scan_cmd(INTERNAL_FUNCTION_PARAMETERS, REDIS_SCAN_TYPE type) {
     zval *object, *z_iter;
     RedisSock *redis_sock;

--- a/redis_array.c
+++ b/redis_array.c
@@ -131,7 +131,7 @@ void redis_destructor_redis_array(zend_resource * rsrc TSRMLS_DC)
 /**
  * redis_array_get
  */
-PHPAPI int redis_array_get(zval *id, RedisArray **ra TSRMLS_DC)
+PHP_REDIS_API int redis_array_get(zval *id, RedisArray **ra TSRMLS_DC)
 {
 
     zval *socket;

--- a/redis_cluster.c
+++ b/redis_cluster.c
@@ -232,7 +232,7 @@ static void ht_free_node(zval *data) {
 }
 
 /* Initialize/Register our RedisCluster exceptions */
-PHPAPI zend_class_entry *rediscluster_get_exception_base(int root TSRMLS_DC) {
+PHP_REDIS_API zend_class_entry *rediscluster_get_exception_base(int root TSRMLS_DC) {
 #if HAVE_SPL
     if(!root) {
         if(!spl_rte_ce) {

--- a/redis_session.c
+++ b/redis_session.c
@@ -70,12 +70,12 @@ typedef struct {
 
 } redis_pool;
 
-PHPAPI redis_pool*
+PHP_REDIS_API redis_pool*
 redis_pool_new(TSRMLS_D) {
     return ecalloc(1, sizeof(redis_pool));
 }
 
-PHPAPI void
+PHP_REDIS_API void
 redis_pool_add(redis_pool *pool, RedisSock *redis_sock, int weight,
         int database, char *prefix, char *auth TSRMLS_DC) {
 
@@ -96,7 +96,7 @@ redis_pool_add(redis_pool *pool, RedisSock *redis_sock, int weight,
     pool->totalWeight += weight;
 }
 
-PHPAPI void
+PHP_REDIS_API void
 redis_pool_free(redis_pool *pool TSRMLS_DC) {
 
     redis_pool_member *rpm, *next;
@@ -149,7 +149,7 @@ redis_pool_member_select(redis_pool_member *rpm TSRMLS_DC) {
     efree(cmd);
 }
 
-PHPAPI redis_pool_member *
+PHP_REDIS_API redis_pool_member *
 redis_pool_get_sock(redis_pool *pool, const char *key TSRMLS_DC) {
 
     unsigned int pos, i;


### PR DESCRIPTION
When I replaced every PHPAPI with PHP_REDIS_API (like it was in the PHP 5-version), I could leave out the PHP_EXPORTS flag and the _basic_globals problem was fixed as well. Without workarounds.

FYI: No extension in my builds has the PHP_EXPORTS flag.
